### PR TITLE
Release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@
 
 - No unreleased changes.
 
+## v3.1.2 - 2026-05-01
+
+Patch release focused on forecast-verification clock semantics.
+
+### Changed
+
+- Forecast horizons now use the simulator/domain clock: `Forecast.deadline_step = created_step + horizon_steps`, where `created_step` is `world.t`.
+- Runtime forecast verification now checks due forecasts against `current_world.t`; `runtime_step` remains the agent-level event/audit clock for queues, snapshots, fallback continuity, and provenance.
+- Forecast query/explanation fields now report `created_at_step` and `due_at_step` on the same domain-step axis.
+- README, API map, and full architecture documentation now describe the domain-step forecast horizon contract.
+- Core package version bumped to `3.1.2`; `freeman-connectors` now targets `freeman>=3.1.2,<4.0.0`.
+
+### Fixed
+
+- Forecasts no longer expire early when the agent runtime advances faster than the simulated domain, when one agent tick includes multiple runtime events, or when a domain is loaded with non-zero `world.t`.
+
+### Validation
+
+- `pytest -q` -> `239 passed`
+
 ## v3.1.1 - 2026-04-25
 
 Patch release focused on release hygiene, explicit ontology-ingestion provenance, and ETL hardening.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Freeman is an analytical agent for situations that change over time. You describ
 
 The point of Freeman is not "chatting about a topic". The point is to keep a structured world model, run repeatable scenario analysis, remember past cases, and give you an audit trail of what changed and why.
 
-Current release: `3.1.1`
+Current release: `3.1.2`
 
 Freeman `3.1` keeps the operational local-agent loop closed and replaces monolithic bootstrap with a structured ETL path:
 

--- a/docs/RELEASE_3_1.md
+++ b/docs/RELEASE_3_1.md
@@ -4,6 +4,8 @@
 
 `3.1.1` hardens that release by making ontology-ingestion provenance explicit, fixing ETL resource normalization, and adding a transparent live-news benchmark harness.
 
+`3.1.2` fixes forecast-verification clock semantics so forecast horizons are evaluated on simulator/domain time (`world.t`) rather than the agent runtime clock.
+
 ## What Changed
 
 - `llm_synthesize` in runtime now uses a two-phase ETL flow instead of one monolithic synthesis prompt:
@@ -51,3 +53,21 @@
 ### Validation
 
 - `pytest -q` -> `238 passed`
+
+## 3.1.2 Follow-up
+
+### What Changed
+
+- Forecast deadlines now use `created_step + horizon_steps`, where `created_step` is the simulator/domain step (`world.t`).
+- Runtime ex-post verification now checks `ForecastRegistry.due(current_world.t)`.
+- `runtime_step` remains the monotonic agent event clock for queues, snapshots, fallback continuity, and audit metadata.
+- Forecast summaries and explanations now report `created_at_step` and `due_at_step` on the same domain-time axis.
+
+### Why It Matters
+
+- Forecast horizons now mean "N SSM steps from forecast creation", independent of how many agent events or fallback paths happen between world updates.
+- Domains loaded at non-zero `world.t` and domains with different runtime cadences no longer verify forecasts too early because the agent clock is ahead.
+
+### Validation
+
+- `pytest -q` -> `239 passed`

--- a/freeman/__init__.py
+++ b/freeman/__init__.py
@@ -4,6 +4,6 @@ from freeman.core.world import WorldGraph, WorldState
 from freeman.domain.compiler import DomainCompiler
 from freeman.game.runner import GameRunner, SimConfig
 
-__version__ = "3.0.0"
+__version__ = "3.1.2"
 
 __all__ = ["__version__", "DomainCompiler", "GameRunner", "SimConfig", "WorldGraph", "WorldState"]

--- a/packages/freeman-connectors/freeman_connectors/__init__.py
+++ b/packages/freeman-connectors/freeman_connectors/__init__.py
@@ -5,7 +5,7 @@ from freeman_connectors.http import HTTPJSONSignalSource
 from freeman_connectors.rss import ArxivSignalSource, RSSFeedSignalSource
 from freeman_connectors.web import WebPageSignalSource
 
-__version__ = "3.0.0"
+__version__ = "3.1.2"
 
 __all__ = [
     "__version__",

--- a/packages/freeman-connectors/pyproject.toml
+++ b/packages/freeman-connectors/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freeman-connectors"
-version = "3.1.1"
+version = "3.1.2"
 description = "Universal signal-source adapters for Freeman."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 dependencies = [
     "beautifulsoup4>=4.12",
     "feedparser>=6.0",
-    "freeman>=3.1.1,<4.0.0",
+    "freeman>=3.1.2,<4.0.0",
     "requests>=2.31",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freeman"
-version = "3.1.1"
+version = "3.1.2"
 description = "Domain-agnostic world simulator for LLM agents."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare Freeman 3.1.2 as a patch release for forecast-verification clock semantics.

This PR:
- bumps the core `freeman` package to `3.1.2`
- bumps `freeman-connectors` to `3.1.2` and updates its dependency to `freeman>=3.1.2,<4.0.0`
- synchronizes runtime `__version__` values for both packages
- updates README, CHANGELOG, and 3.1 release notes

## Root Cause

The 3.1.2 patch follows the fix where forecast horizons are evaluated on simulator/domain time (`world.t`) instead of the agent runtime clock (`runtime_step`). This keeps `horizon_steps` semantically equal to N SSM/domain steps from forecast creation.

## Validation

- `pytest -q` -> `239 passed`
- `python -m build --outdir /tmp/freeman-release-3.1.2-dist` -> built `freeman-3.1.2.tar.gz` and `freeman-3.1.2-py3-none-any.whl`
- `python -m build packages/freeman-connectors --outdir /tmp/freeman-connectors-3.1.2-dist` -> built `freeman_connectors-3.1.2.tar.gz` and `freeman_connectors-3.1.2-py3-none-any.whl`
